### PR TITLE
Add api_url as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ version is updated when new features are released.
 | Input              | Default                   | Description                                                                                                                                |
 | ------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `allow-prerelease` | `'true'`                  | If `check-only` is `'true'`, this controls if the check should pass if a matching prerelease version is detected (e.g. `v1.0.0-SNAPSHOT`). |
+| `api_url`          | `${{ github.api_url }}`   | The GitHub API URL to use                                                                                                                  |
 | `check-only`       | `'false'`                 | If set to `'true'`, only checks if the version exists. Fails the action if the version already exists.                                     |
 | `comment`          | `'true'`                  | If set to `'true'`, a comment will be added to the pull request indicating if the version is valid or conflicts with an existing version.  |
 | `manifest-path`    |                           | The path to the manifest that contains the version (relative to the root of the repository).                                               |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -46,6 +46,7 @@ describe('main', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('true') // allow-prerelease
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('false') // check-only
       .mockReturnValueOnce('/fixtures/valid/node/package.json') // manifest-path
       .mockReturnValueOnce('true') // overwrite
@@ -64,6 +65,7 @@ describe('main', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('true') // allow-prerelease
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('false') // check-only
       .mockReturnValueOnce('') // manifest-path
       .mockReturnValueOnce('true') // overwrite
@@ -83,6 +85,7 @@ describe('main', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('true') // allow-prerelease
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('false') // check-only
       .mockReturnValueOnce('/fixtures/valid/node/package.json') // manifest-path
       .mockReturnValueOnce('true') // overwrite
@@ -193,6 +196,7 @@ describe('main', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('true') // allow-prerelease
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('false') // check-only
       .mockReturnValueOnce('/fixtures/valid/node/package.json') // manifest-path
       .mockReturnValueOnce('false') // overwrite
@@ -226,6 +230,7 @@ describe('main', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('true') // allow-prerelease
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('true') // check-only
       .mockReturnValueOnce('/fixtures/valid/node/package.json') // manifest-path
       .mockReturnValueOnce('false') // overwrite

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
       When `check-only` is set to 'true', this will allow prerelease versions to
       pass. Defaults to 'true'.
     required: false
+  api_url:
+    description: The GitHub API URL to use.
+    required: false
+    default: ${{ github.api_url }}
   check-only:
     default: 'false'
     description:

--- a/dist/index.js
+++ b/dist/index.js
@@ -44804,6 +44804,7 @@ class Version {
 
 async function run() {
     const allowPrerelease = coreExports.getInput('allow-prerelease') === 'true';
+    const apiUrl = coreExports.getInput('api_url', { required: true });
     const checkOnly = coreExports.getInput('check-only') === 'true';
     const manifestPath = coreExports.getInput('manifest-path');
     const overwrite = coreExports.getInput('overwrite') === 'true';
@@ -44817,6 +44818,7 @@ async function run() {
         return coreExports.setFailed('Must provide manifest-path OR use-version');
     coreExports.info('Running action with inputs:');
     coreExports.info(`\tAllow Prerelease: ${allowPrerelease}`);
+    coreExports.info(`\tAPI URL: ${apiUrl}`);
     coreExports.info(`\tCheck: ${checkOnly}`);
     coreExports.info(`\tManifest Path: ${manifestPath}`);
     coreExports.info(`\tOverwrite: ${overwrite}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -31242,7 +31242,9 @@ var githubExports = requireGithub();
  * @returns The ID of the previous version check comment, or undefined
  */
 async function getCommentId() {
-    const octokit = githubExports.getOctokit(coreExports.getInput('token', { required: true }));
+    const octokit = githubExports.getOctokit(coreExports.getInput('token', { required: true }), {
+        baseUrl: coreExports.getInput('api_url', { required: true })
+    });
     // Unique identifier for the version check comment.
     const identifier = `<!-- semver: workflow=${githubExports.context.workflow} -->`;
     // If no existing comment is found, set the result to undefined.
@@ -31264,7 +31266,9 @@ async function getCommentId() {
  * @param manifestPath The path to the manifest file being checked
  */
 async function versionCheckComment(success, manifestPath) {
-    const octokit = githubExports.getOctokit(coreExports.getInput('token', { required: true }));
+    const octokit = githubExports.getOctokit(coreExports.getInput('token', { required: true }), {
+        baseUrl: coreExports.getInput('api_url', { required: true })
+    });
     const successBody = [
         '### Semantic Version Check Passed :white_check_mark:',
         `Version in manifest file \`${manifestPath}\` is valid.`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issue-ops-semver",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issue-ops-semver",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "issue-ops-semver",
   "description": "Semantically version GitHub repository tags",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "homepage": "https://github.com/issue-ops/semver#readme",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { Version } from './version.js'
 
 export async function run() {
   const allowPrerelease: boolean = core.getInput('allow-prerelease') === 'true'
+  const apiUrl: string = core.getInput('api_url', { required: true })
   const checkOnly: boolean = core.getInput('check-only') === 'true'
   const manifestPath: string = core.getInput('manifest-path')
   const overwrite: boolean = core.getInput('overwrite') === 'true'
@@ -22,6 +23,7 @@ export async function run() {
 
   core.info('Running action with inputs:')
   core.info(`\tAllow Prerelease: ${allowPrerelease}`)
+  core.info(`\tAPI URL: ${apiUrl}`)
   core.info(`\tCheck: ${checkOnly}`)
   core.info(`\tManifest Path: ${manifestPath}`)
   core.info(`\tOverwrite: ${overwrite}`)

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -8,7 +8,12 @@ import * as github from '@actions/github'
  * @returns The ID of the previous version check comment, or undefined
  */
 export async function getCommentId(): Promise<number | undefined> {
-  const octokit = github.getOctokit(core.getInput('token', { required: true }))
+  const octokit = github.getOctokit(
+    core.getInput('token', { required: true }),
+    {
+      baseUrl: core.getInput('api_url', { required: true })
+    }
+  )
 
   // Unique identifier for the version check comment.
   const identifier = `<!-- semver: workflow=${github.context.workflow} -->`
@@ -38,7 +43,12 @@ export async function versionCheckComment(
   success: boolean,
   manifestPath: string
 ): Promise<void> {
-  const octokit = github.getOctokit(core.getInput('token', { required: true }))
+  const octokit = github.getOctokit(
+    core.getInput('token', { required: true }),
+    {
+      baseUrl: core.getInput('api_url', { required: true })
+    }
+  )
 
   const successBody = [
     '### Semantic Version Check Passed :white_check_mark:',


### PR DESCRIPTION
This pull request introduces a new input parameter, `api_url`, to allow customization of the GitHub API URL, updates the package version to `2.5.0`, and modifies the code to use the new input parameter for API requests. These changes enhance flexibility and ensure compatibility with alternative GitHub API endpoints.